### PR TITLE
updating ipfs-api link to new name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**Unmaintained. See [ipfs-api](https://github.com/tbenett/ruby-ipfs-api) instead.**
+**Unmaintained. See [ruby-pfs-http-client](https://github.com/tbenett/ruby-ipfs-http-client) instead.**
 
 # IPFS API Bindings for Ruby
 


### PR DESCRIPTION
I changed the name of my repo in accordance to this issue https://github.com/ipfs/ipfs/issues/374

Thank you!